### PR TITLE
Fix delayed collision interrupt time

### DIFF
--- a/src/ar_interaction.hpp
+++ b/src/ar_interaction.hpp
@@ -1217,7 +1217,7 @@ public:
                                 p2->setBinaryPairID(p1->id);
                                 p1->setBinaryInterruptState(BinaryInterruptState::collision);
                                 p2->setBinaryInterruptState(BinaryInterruptState::collision);
-                                p1->time_interrupt = std::min(_bin_interrupt.time_now + drdv<0 ? t_peri : (_bin.period - t_peri), time_interrupt_max);
+                                p1->time_interrupt = std::min(_bin_interrupt.time_now + (drdv<0 ? t_peri : (_bin.period - t_peri)), time_interrupt_max);
                                 p2->time_interrupt = p1->time_interrupt;
                                     
                             }


### PR DESCRIPTION
This fixes the delayed collision interrupt time in the slowdown merger check without BSE.

The old expression:

    _bin_interrupt.time_now + drdv<0 ? t_peri : (_bin.period - t_peri)

is parsed as:

    ((_bin_interrupt.time_now + drdv) < 0) ? t_peri : (_bin.period - t_peri)

so the stored interrupt time loses the `time_now` offset and the branch condition mixes the current time with `r dot v`. The intended logic is to choose the time interval to the next peri-centre using `drdv < 0`, then add that interval to `_bin_interrupt.time_now`.

This patch makes the interval explicit as `time_to_peri` and stores:

    _bin_interrupt.time_now + time_to_peri